### PR TITLE
chore(repo): bump vite version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6354,9 +6354,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.32",


### PR DESCRIPTION
# npm audit report

vite  5.0.0 - 5.0.11
Severity: high
Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem - https://github.com/advisories/GHSA-c24v-8rfc-w8vw
fix available via `npm audit fix`
node_modules/vite

1 high severity vulnerability

To address all issues, run:
  npm audit fix