### PR TITLE
chore(repo): Patch CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,7 @@
 
 ### Features
 
-* **components:** add button and anchor button ([e993e55](https://github.com/gemini-ui/gemini-ui-monorepo/commit/e993e5541db7190fc68c79a32b339a26e022e7ef))
-* **components:** add card component ([#10](https://github.com/gemini-ui/gemini-ui-monorepo/issues/10)) ([63ae6dc](https://github.com/gemini-ui/gemini-ui-monorepo/commit/63ae6dcee68313ee20eedeacaee05810eaef80c3))
-* **components:** Add dynamic glow support for alert ([#23](https://github.com/gemini-ui/gemini-ui-monorepo/issues/23)) ([bd767a6](https://github.com/gemini-ui/gemini-ui-monorepo/commit/bd767a6eeb32c4fb61c43331096cbe796fe892bc))
-* **components:** Add image component ([#25](https://github.com/gemini-ui/gemini-ui-monorepo/issues/25)) ([e50895c](https://github.com/gemini-ui/gemini-ui-monorepo/commit/e50895c9fd2b0ebf9292d4a88f9eb1cd84e226f8))
-* **components:** Added Alert component ([#22](https://github.com/gemini-ui/gemini-ui-monorepo/issues/22)) ([bda1d82](https://github.com/gemini-ui/gemini-ui-monorepo/commit/bda1d822037d6c4d4ea3d14564a4167f4c24337c))
-* **components:** Added basic Grid component ([#9](https://github.com/gemini-ui/gemini-ui-monorepo/issues/9)) ([d703b65](https://github.com/gemini-ui/gemini-ui-monorepo/commit/d703b6522a01543595d2ba082ee8bf48e019db06))
-* **components:** Added Divider component ([#15](https://github.com/gemini-ui/gemini-ui-monorepo/issues/15)) ([65b7f92](https://github.com/gemini-ui/gemini-ui-monorepo/commit/65b7f92cfe6faab9306e552561ff0ae066e55534))
-* **components:** configurable gap for `Grid` component ([71c872a](https://github.com/gemini-ui/gemini-ui-monorepo/commit/71c872a5b0d2248d5a25c12610d0c03e4cb681ce))
-* **core:** add `getSizeProp` and types ([2649d24](https://github.com/gemini-ui/gemini-ui-monorepo/commit/2649d2461e51890130241d142a153d28d5621ab2))
-* **styles:** add @gemini-ui-astro/styles ([b79dc82](https://github.com/gemini-ui/gemini-ui-monorepo/commit/b79dc82d49d4e52b7c8f0eecfa858b6b8bacafe2))
-* **website:** add website basic content ([4e48f4b](https://github.com/gemini-ui/gemini-ui-monorepo/commit/4e48f4b4b61ffcf5b99f81c66b389846ade5a338))
-* **website:** move package docs to new path ([37c0e96](https://github.com/gemini-ui/gemini-ui-monorepo/commit/37c0e9637b8152a823f3d51fe98102385865e2b7))
-* **website:** update page titles ([34bc44f](https://github.com/gemini-ui/gemini-ui-monorepo/commit/34bc44f30e5fe597ddb12dded5d8da5e0f5b1a18))
-* **website:** use global style variables ([3fef90a](https://github.com/gemini-ui/gemini-ui-monorepo/commit/3fef90adc0a878d2ec6cc63f1831a2e78e625262))
-
-
-### Bug Fixes
-
-* **website:** fix broken import preventing deployment ([5e27cef](https://github.com/gemini-ui/gemini-ui-monorepo/commit/5e27cefe98984cda8bb17da316fec749618621d1))
-
-## [0.0.2](https://github.com/gemini-ui/gemini-ui-monorepo/compare/gemini-ui-v0.0.1...gemini-ui-v0.0.2) (2024-01-24)
+* **repo:** add release workflow ([56d1cfd](https://github.com/gemini-ui/gemini-ui-monorepo/commit/56d1cfd03843764bd38d449a3b4a2eb2d99d3793))
 
 
 ### Features


### PR DESCRIPTION
The CHANGELOG ended up with duplicate entries because I force pushed to main then re-merged the changes in https://github.com/gemini-ui/gemini-ui-monorepo/pull/37 ... Hopefully this will fix it 😅